### PR TITLE
Update to nom 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ version = "0.2.0"
 authors = ["Erin <erin@hashbang.sh>"]
 
 [dependencies.nom]
-version = "^4.0"
+version = "^5.0"


### PR DESCRIPTION
On top of that, I ran cargo-fmt and further generalized the error and return types to allow more general usage.

I am planning to use this crate or code like it in the [cargo output parser of the google-apis project](https://github.com/google-apis-rs/generator/issues/12).

Right now I don't know if it actually works, but will certainly update this PR if I make further improvements.

If you think it works, a release on Crates.io would be appreciated.